### PR TITLE
Reduce startup load for ceasar_cipher

### DIFF
--- a/Ceasar_Cypher/Dockerfile
+++ b/Ceasar_Cypher/Dockerfile
@@ -10,6 +10,14 @@ COPY ./requirements.txt /usr/local/bin/requirements.txt
 # Make the startup script executable
 RUN chmod +x /usr/local/bin/start.sh
 
+
+# Update package list and install python3-venv if not already installed
+RUN apt-get update && apt-get install -y python3-venv
+
+
+RUN python3 -m venv /usr/local/bin/venv && \
+    /usr/local/bin/venv/bin/pip install -r /usr/local/bin/requirements.txt
+
 # Set the entrypoint to the startup script
 ENTRYPOINT ["/usr/local/bin/start.sh"]
 

--- a/Ceasar_Cypher/start.sh
+++ b/Ceasar_Cypher/start.sh
@@ -1,19 +1,7 @@
 #!/bin/bash
 
-# Update package list and install python3-venv if not already installed
-apt-get update && apt-get install -y python3-venv
-
-# Create a virtual environment
-python3 -m venv /usr/local/bin/venv
-
-# Activate the virtual environment
-source /usr/local/bin/venv/bin/activate
-
-# Install required packages
-pip install -r /usr/local/bin/requirements.txt
-
 # Run the Python script
-python /usr/local/bin/script.py
+/usr/local/bin/venv/bin/python /usr/local/bin/script.py
 
 # Start Apache server
 httpd-foreground


### PR DESCRIPTION
Moved generating and installing a python environment from on startup to on docker compose build, was tested and run.